### PR TITLE
Fixed BorderBrush value in BorderStyles.xaml

### DIFF
--- a/src/Citrus.Avalonia/Theme/BorderStyles.xaml
+++ b/src/Citrus.Avalonia/Theme/BorderStyles.xaml
@@ -4,7 +4,7 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="CornerRadius" Value="5" />
         <Setter Property="BorderThickness" Value="2 1 2 4" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
         <Setter Property="Background" Value="{DynamicResource ThemeCardBrush}" />
         <Setter Property="Margin" Value="7" />
     </Style>


### PR DESCRIPTION
## Changes
- Fixed `BorderBrush` value in `BorderStyles.xaml`.

Context: This causes an error in Avalonia nightly builds.